### PR TITLE
fix boundary check for valid devices

### DIFF
--- a/pyKCS_Utility.py
+++ b/pyKCS_Utility.py
@@ -441,7 +441,7 @@ def init_dos(from_settings):
                 
             device_id = int(input("Device ID:"))  
         
-            while device_id > rec_devices or device_id < 0:
+            while device_id >= rec_devices or device_id < 0:
                 print("Cant find that ID")
                 device_id = int(input("Device ID:")) 
 


### PR DESCRIPTION
My computer has devices 0,1,2,3, and in my monkey testing I managed to input 4 as the value; this is because the last valid device index is one less than the number of devices. I have fixed it here.